### PR TITLE
Changed import to import_restrictions in encryption-laws template.

### DIFF
--- a/map.md
+++ b/map.md
@@ -66,7 +66,7 @@ permalink: /map/
 
 <script id="view-encryptionlaws" type="text/template">
   <li>
-    <% if (import) { %><strong>Import</strong>: <%= import %><br><% } %>
+    <% if (import_restrictions) { %><strong>Import</strong>: <%= import_restrictions %><br><% } %>
     <% if (prohibit_user) { %><strong>Prohibit Use</strong>: <%= prohibit_user %><br><% } %>
     <% if (license_use) { %><strong>License Use</strong>: <%= license_use %><br><% } %>
     <% if (provide_keys) { %><strpong>Provide Keys</strong>: <%= provide_keys %><% } %>


### PR DESCRIPTION
'import' is a restricted JavaScript keyword and caused a syntax error.

The pull request on the data-encryptionlaws repository needs to be accepted too for this to work.
